### PR TITLE
Add changed files/folders to the test collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ target/
 # pyenv
 .python-version
 
+# pytest
+.pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Filter tests according with pytest file convention
+- Only collects the tests from `git status`
 
 ## [0.1.0] - 2018-05-24
 ### Added
 - Run the tests according with changed files
 
 [Unreleased]: https://github.com/anapaulagomes/pytest-picked/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/anapaulagomes/pytest-picked/compare/v0.3.0...v0.1.0
+[0.1.0]: https://github.com/anapaulagomes/pytest-picked/compare/a5d86647c511ea56d0d4c42b416b2d7bac8111f6...v0.1.0


### PR DESCRIPTION
In the current version (0.1.0) we're modifying the collected tests. Meaning: pytest was collecting all the tests and then filtering the changed ones. With this change, I'm adding the changed files/folders to be collected. This change must speed things up.
I was thinking about changing the `testpaths` variable but [I don't think it's possible](https://github.com/pytest-dev/pytest/issues/3109) to do it on `pytest_configure`.