### PR TITLE
Feature/5 collect only actual test matter

### DIFF
--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -21,8 +21,8 @@ def pytest_collection_modifyitems(items, config):
     if not picked_plugin:
         return
 
-    test_files = config._getini('python_files')
-    picked_files, picked_folders = _affected_tests(test_files)
+    test_file_convention = config._getini('python_files')
+    picked_files, picked_folders = _affected_tests(test_file_convention)
     _display_affected_tests(config, picked_files, picked_folders)
 
     to_be_tested = []
@@ -48,7 +48,7 @@ def _display_affected_tests(config, files, folders):
     writer.line(folders_msg)
 
 
-def _affected_tests(test_files):
+def _affected_tests(test_file_convention):
     """
     Parse affected tests from `git status --short`.
 
@@ -69,7 +69,7 @@ def _affected_tests(test_files):
     raw_output = _get_git_status()
 
     re_list = [item.replace('.', '\.').replace('*', '.*')
-               for item in test_files]
+               for item in test_file_convention]
     re_string = "|".join(re_list)
 
     folders, files = [], []

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -1,6 +1,8 @@
 import re
 import subprocess
 
+from pathlib import Path
+
 import _pytest.config
 
 
@@ -73,8 +75,10 @@ def _affected_tests(test_files):
     for candidate in raw_output.splitlines():
         file_or_folder = _extract_file_or_folder(candidate)
 
-        if "test" in file_or_folder:
-            if file_or_folder.endswith("/"):
+        if file_or_folder.endswith("/"):
+            path = Path(file_or_folder)
+            test_in_folders = any([part.startswith("test") for part in path.parts])
+            if test_in_folders:
                 folders.append(file_or_folder)
         elif re.search(re_string, candidate):
             files.append(file_or_folder)

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 
 import _pytest.config
@@ -65,6 +66,9 @@ def _affected_tests(test_files):
     """
     raw_output = _get_git_status()
 
+    re_list = [item.replace('.', '\.').replace('*', '.*') for item in test_files]
+    re_string = "|".join(re_list)
+
     folders, files = [], []
     for candidate in raw_output.splitlines():
         file_or_folder = _extract_file_or_folder(candidate)
@@ -72,8 +76,8 @@ def _affected_tests(test_files):
         if "test" in file_or_folder:
             if file_or_folder.endswith("/"):
                 folders.append(file_or_folder)
-            elif file_or_folder.endswith(".py"):
-                files.append(file_or_folder)
+        elif re.search(re_string, candidate):
+            files.append(file_or_folder)
     return files, folders
 
 

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -68,7 +68,8 @@ def _affected_tests(test_files):
     """
     raw_output = _get_git_status()
 
-    re_list = [item.replace('.', '\.').replace('*', '.*') for item in test_files]
+    re_list = [item.replace('.', '\.').replace('*', '.*')
+               for item in test_files]
     re_string = "|".join(re_list)
 
     folders, files = [], []
@@ -77,8 +78,7 @@ def _affected_tests(test_files):
 
         if file_or_folder.endswith("/"):
             path = Path(file_or_folder)
-            test_in_folders = any([part.startswith("test") for part in path.parts])
-            if test_in_folders:
+            if any([part.startswith("test") for part in path.parts]):
                 folders.append(file_or_folder)
         elif re.search(re_string, candidate):
             files.append(file_or_folder)

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -21,7 +21,7 @@ def pytest_collection_modifyitems(items, config):
     if not picked_plugin:
         return
 
-    test_file_convention = config._getini('python_files')
+    test_file_convention = config._getini("python_files")
     picked_files, picked_folders = _affected_tests(test_file_convention)
     _display_affected_tests(config, picked_files, picked_folders)
 
@@ -68,7 +68,7 @@ def _affected_tests(test_file_convention):
     """
     raw_output = _get_git_status()
 
-    re_list = [item.replace('.', '\.').replace('*', '.*')
+    re_list = [item.replace(".", "\.").replace("*", ".*")
                for item in test_file_convention]
     re_string = "|".join(re_list)
 

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -1,8 +1,6 @@
 import re
 import subprocess
 
-from pathlib import Path
-
 import _pytest.config
 
 
@@ -77,9 +75,7 @@ def _affected_tests(test_file_convention):
         file_or_folder = _extract_file_or_folder(candidate)
 
         if file_or_folder.endswith("/"):
-            path = Path(file_or_folder)
-            if any([part.startswith("test") for part in path.parts]):
-                folders.append(file_or_folder)
+            folders.append(file_or_folder)
         elif re.search(re_string, candidate):
             files.append(file_or_folder)
     return files, folders

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -18,7 +18,8 @@ def pytest_collection_modifyitems(items, config):
     if not picked_plugin:
         return
 
-    picked_files, picked_folders = _affected_tests()
+    test_files = config._getini('python_files')
+    picked_files, picked_folders = _affected_tests(test_files)
     _display_affected_tests(config, picked_files, picked_folders)
 
     to_be_tested = []
@@ -44,7 +45,7 @@ def _display_affected_tests(config, files, folders):
     writer.line(folders_msg)
 
 
-def _affected_tests():
+def _affected_tests(test_files):
     """
     Parse affected tests from `git status --short`.
 

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -141,7 +141,8 @@ def test_check_parser():
             + b" U tests/test_pytest_picked.py\n"
             + b"?? random/tests/\n"
             + b" M intestine.py\n"
-            + b"?? random/attest/\n"
+            + b"?? api/\n"
+            + b" M tests_new/intestine.py\n"
         )
 
         subprocess_mock.return_value.stdout = output
@@ -153,7 +154,7 @@ def test_check_parser():
             "school/tests/test_rescue_students.py",
             "tests/test_pytest_picked.py",
         ]
-        expected_folders = ["tests/", "random/tests/"]
+        expected_folders = ["tests/", "random/tests/", "api/"]
 
         assert files == expected_files
         assert folders == expected_folders

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -139,11 +139,14 @@ def test_check_parser():
             + b" M picked.py\n"
             + b"A  setup.py\n"
             + b" U tests/test_pytest_picked.py\n"
-            + b"?? random/tests/"
+            + b"?? random/tests/\n"
+            + b" M intestine.py\n"
+            + b"?? random/attest/\n"
         )
 
         subprocess_mock.return_value.stdout = output
-        files, folders = _affected_tests()
+        test_files = ["test_*.py", "*_test.py"]
+        files, folders = _affected_tests(test_files)
 
         expected_files = [
             "test_new_things.py",


### PR DESCRIPTION
Hi,

Thanks for the tip on finding the parsing string. From there, the problem just unravelled.

I have very mixed feelings on folder discovery. I'm not at all sure it is practical if the module finds all the test files. Is there a particular philosophy on it?

Also, is there any chance to add vim stuff to `.gitignore`? The swap files keep trying to get committed.
Thanks.