### PR TITLE
Add option to run tests modified in the current branch

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -253,7 +253,9 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "pytest-pytest-picked", u"picked Documentation", [author], 1)]
+man_pages = [
+    (master_doc, "pytest-pytest-picked", u"picked Documentation", [author], 1)
+]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False

--- a/modes.py
+++ b/modes.py
@@ -1,0 +1,74 @@
+import re
+import subprocess  # nosec
+from abc import ABC, abstractmethod
+
+
+class Mode(ABC):
+
+    def __init__(self, test_file_convention):
+        self.test_file_convention = test_file_convention
+
+    def affected_tests(self):
+        raw_output = self.git_output()
+
+        re_list = [
+            item.replace(".", r"\.").replace("*", ".*")
+            for item in self.test_file_convention
+        ]
+        re_string = r"(\/|^)" + r"|".join(re_list)
+
+        folders, files = [], []
+        for candidate in raw_output.splitlines():
+            file_or_folder = self.parser(candidate)
+            if file_or_folder.endswith("/"):
+                folders.append(file_or_folder)
+            elif re.search(re_string, file_or_folder):
+                files.append(file_or_folder)
+        return files, folders
+
+    def git_output(self):
+        output = subprocess.run(self.command(), stdout=subprocess.PIPE)
+        return output.stdout.decode("utf-8")
+
+    def print_command(self):
+        return " ".join(self.command())
+
+    def __str__(self):
+        return (
+            f"Mode: {self.__class__.__name__}\nCommand: {self.print_command()} Parser rule: {self.parser.__doc__}"
+        )
+
+    @property
+    @abstractmethod
+    def command(self):
+        pass
+
+    @abstractmethod
+    def parser(self, candidate):
+        pass
+
+
+class Branch(Mode):
+
+    def command(self):
+        return ["git", "diff", "--name-only", "master"]
+
+    def parser(self, candidate):
+        """The candidate itself."""
+        return candidate
+
+
+class Unstaged(Mode):
+
+    def command(self):
+        return ["git", "status", "--short"]
+
+    def parser(self, candidate):
+        """Discard the first 3 characters."""
+        start_path_index = 3
+        rename_indicator = "-> "
+
+        if rename_indicator in candidate:
+            indicator_index = candidate.find(rename_indicator)
+            start_path_index = indicator_index + len(rename_indicator)
+        return candidate[start_path_index:]

--- a/pytest_picked.py
+++ b/pytest_picked.py
@@ -1,7 +1,6 @@
-import re
-import subprocess  # nosec
-
 import _pytest
+
+from modes import Branch, Unstaged
 
 
 def pytest_addoption(parser):
@@ -28,13 +27,15 @@ def pytest_configure(config):
         return
 
     picked_mode = config.getoption("picked_mode")
-    raw_output = _get_git_status(picked_mode)
-
     test_file_convention = config._getini("python_files")  # pylint: disable=W0212
 
-    picked_files, picked_folders = _affected_tests(
-        raw_output, test_file_convention, mode=picked_mode
-    )
+    if picked_mode == "branch":
+        mode = Branch(test_file_convention)
+    else:
+        mode = Unstaged(test_file_convention)
+
+    picked_files, picked_folders = mode.affected_tests()
+
     config.args = picked_files + picked_folders
 
     _display_affected_tests(config, picked_files, picked_folders)
@@ -48,59 +49,3 @@ def _display_affected_tests(config, files, folders):
     folders_msg = message.format("folders", len(folders), folders)
     writer.line(files_msg)
     writer.line(folders_msg)
-
-
-def _affected_tests(raw_output, test_file_convention, mode="unstaged"):
-    """
-    Parse affected tests from `git status --short`.
-
-    The command output would look like this:
-    A  setup.py
-     U tests/test_pytest_picked.py
-    ?? .pylintrc
-
-    The first two digits are M, A, D, R, C, U, ? or !
-    The third is a white-space and the left is the path of
-    the file.
-    If the file was renamed, it will look like this:
-    R  school/migrations/from-school.csv -> new-things-from-school.csv
-
-    Reference:
-    https://git-scm.com/docs/git-status#git-status---short
-    """
-    re_list = [
-        item.replace(".", r"\.").replace("*", ".*") for item in test_file_convention
-    ]
-    re_string = r"(\/|^)" + r"|".join(re_list)
-
-    folders, files = [], []
-    for candidate in raw_output.splitlines():
-        if mode == "unstaged":
-            file_or_folder = _extract_file_or_folder(candidate)
-        else:
-            file_or_folder = candidate
-
-        if file_or_folder.endswith("/"):
-            folders.append(file_or_folder)
-        elif re.search(re_string, file_or_folder):
-            files.append(file_or_folder)
-    return files, folders
-
-
-def _extract_file_or_folder(candidate):
-    start_path_index = 3
-    rename_indicator = "-> "
-
-    if rename_indicator in candidate:
-        indicator_index = candidate.find(rename_indicator)
-        start_path_index = indicator_index + len(rename_indicator)
-    return candidate[start_path_index:]
-
-
-def _get_git_status(mode="unstaged"):
-    if mode == "unstaged":
-        command = ["git", "status", "--short"]
-    else:
-        command = ["git", "diff", "--name-only", "master"]
-    output = subprocess.run(command, stdout=subprocess.PIPE)
-    return output.stdout.decode("utf-8")

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -34,8 +34,8 @@ class Mode(ABC):
         return " ".join(self.command())
 
     def __str__(self):
-        return (
-            f"Mode: {self.__class__.__name__}\nCommand: {self.print_command()} Parser rule: {self.parser.__doc__}"
+        return "Mode: {}\nCommand: {} Parser rule: {}".format(
+            self.__class__.__name__, self.print_command(), self.parser.__doc__
         )
 
     @property

--- a/pytest_picked/plugin.py
+++ b/pytest_picked/plugin.py
@@ -1,6 +1,6 @@
 import _pytest
 
-from modes import Branch, Unstaged
+from .modes import Branch, Unstaged
 
 
 def pytest_addoption(parser):
@@ -27,7 +27,9 @@ def pytest_configure(config):
         return
 
     picked_mode = config.getoption("picked_mode")
-    test_file_convention = config._getini("python_files")  # pylint: disable=W0212
+    test_file_convention = config._getini(  # pylint: disable=W0212
+        "python_files"
+    )
 
     if picked_mode == "branch":
         mode = Branch(test_file_convention)

--- a/pytest_picked/plugin.py
+++ b/pytest_picked/plugin.py
@@ -31,10 +31,11 @@ def pytest_configure(config):
         "python_files"
     )
 
-    if picked_mode == "branch":
-        mode = Branch(test_file_convention)
-    else:
-        mode = Unstaged(test_file_convention)
+    modes = {
+        "branch": Branch(test_file_convention),
+        "unstaged": Unstaged(test_file_convention),
+    }
+    mode = modes.get(picked_mode, "unstaged")
 
     picked_files, picked_folders = mode.affected_tests()
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import codecs
 import os
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 def read(fname):
@@ -23,7 +23,7 @@ setup(
     url="https://github.com/anapaulagomes/pytest-picked",
     description="Run the tests related to the changed files",
     long_description=read("README.rst"),
-    py_modules=["pytest_picked"],
+    packages=find_packages(exclude=["tests", "docs"]),
     python_requires=">=3.5",
     install_requires=["pytest>=3.5.0"],
     classifiers=[
@@ -39,5 +39,5 @@ setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
     ],
-    entry_points={"pytest11": ["picked = pytest_picked"]},
+    entry_points={"pytest11": ["picked = pytest_picked.plugin"]},
 )

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,60 +1,112 @@
 from unittest.mock import patch
 
+import pytest
+
 from pytest_picked.modes import Branch, Unstaged
 
 
-def test_check_parser():
-    test_file_convention = ["test_*.py", "*_test.py"]
-    raw_output = (
-        b"R  school/migrations/from-school.csv -> test_new_things.py\n"
-        + b"D  school/migrations/0032_auto_20180515_1308.py\n"
-        + b"?? Pipfile\n"
-        + b"!! school/tests/test_rescue_students.py\n"
-        + b"C  tests/\n"
-        + b" M .pre-commit-config.yaml\n"
-        + b" M picked.py\n"
-        + b"A  setup.py\n"
-        + b" U tests/test_pytest_picked.py\n"
-        + b"?? random/tests/\n"
-        + b" M intestine.py\n"
-        + b"?? api/\n"
-        + b" M tests_new/intestine.py\n"
+class TestUnstaged:
+
+    def test_should_return_git_status_command(self):
+        mode = Unstaged([])
+        command = mode.command()
+
+        assert isinstance(command, list)
+        assert mode.command() == ["git", "status", "--short"]
+
+    @pytest.mark.parametrize(
+        "line,expected_line",
+        [
+            (" D tests/migrations/auto.py", None),
+            (
+                "R  tests/from-school.csv -> test_new_things.py",
+                "test_new_things.py",
+            ),
+            (
+                "R  tests/from-school.csv -> tests/test_new_things.py",
+                "tests/test_new_things.py",
+            ),
+            (" M test.py", "test.py"),
+            ("AD test.py", None),
+            ("?? api/", "api/"),
+        ],
     )
+    def test_parser_should_ignore_no_paths_characteres(
+        self, line, expected_line
+    ):
+        mode = Unstaged([])
+        parsed_line = mode.parser(line)
 
-    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
-        subprocess_mock.return_value.stdout = raw_output
-        mode = Unstaged(test_file_convention)
-        files, folders = mode.affected_tests()
+        assert parsed_line == expected_line
 
-    expected_files = [
-        "test_new_things.py",
-        "school/tests/test_rescue_students.py",
-        "tests/test_pytest_picked.py",
-    ]
-    expected_folders = ["tests/", "random/tests/", "api/"]
+    def test_should_list_unstaged_changed_files_as_affected_tests(self):
+        test_file_convention = ["test_*.py", "*_test.py"]
+        raw_output = (
+            b"R  school/migrations/from-school.csv -> test_new_things.py\n"
+            + b"D  school/migrations/0032_auto_20180515_1308.py\n"
+            + b"?? Pipfile\n"
+            + b"!! school/tests/test_rescue_students.py\n"
+            + b"C  tests/\n"
+            + b" M .pre-commit-config.yaml\n"
+            + b" M picked.py\n"
+            + b"A  setup.py\n"
+            + b" U tests/test_pytest_picked.py\n"
+            + b"?? random/tests/\n"
+            + b" M intestine.py\n"
+            + b"?? api/\n"
+            + b" M tests_new/intestine.py\n"
+        )
 
-    assert files == expected_files
-    assert folders == expected_folders
+        with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
+            subprocess_mock.return_value.stdout = raw_output
+            mode = Unstaged(test_file_convention)
+            files, folders = mode.affected_tests()
+
+        expected_files = [
+            "test_new_things.py",
+            "school/tests/test_rescue_students.py",
+            "tests/test_pytest_picked.py",
+        ]
+        expected_folders = ["tests/", "random/tests/", "api/"]
+
+        assert files == expected_files
+        assert folders == expected_folders
 
 
-def test_should_parse_branch_changed_files():
-    raw_output = (
-        b"pytest_picked.py\n"
-        + b"tests/test_pytest_picked.py\n"
-        + b"tests/test_other_module.py"
-    )
-    test_file_convention = ["test_*.py", "*_test.py"]
+class TestBranch:
 
-    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
-        subprocess_mock.return_value.stdout = raw_output
-        mode = Branch(test_file_convention)
-        files, folders = mode.affected_tests()
+    def test_should_return_command_that_list_all_changed_files(self):
+        mode = Branch([])
+        command = mode.command()
 
-    expected_files = [
-        "tests/test_pytest_picked.py",
-        "tests/test_other_module.py",
-    ]
-    expected_folders = []
+        assert isinstance(command, list)
+        assert mode.command() == ["git", "diff", "--name-only", "master"]
 
-    assert files == expected_files
-    assert folders == expected_folders
+    def test_parser_should_return_the_candidate_itself(self):
+        mode = Branch([])
+        line = "tests/test_pytest_picked.py\n"
+        parsed_line = mode.parser(line)
+
+        assert parsed_line == line
+
+    def test_should_list_branch_changed_files_as_affected_tests(self):
+        raw_output = (
+            b"pytest_picked.py\n"
+            + b"tests/test_pytest_picked.py\n"
+            + b"tests/test_other_module.py"
+        )
+        test_file_convention = ["test_*.py", "*_test.py"]
+
+        with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
+            subprocess_mock.return_value.stdout = raw_output
+            mode = Branch(test_file_convention)
+            files, folders = mode.affected_tests()
+
+        expected_files = [
+            "tests/test_pytest_picked.py",
+            "tests/test_other_module.py",
+        ]
+        expected_folders = []
+
+        assert files == expected_files
+        assert folders == expected_folders

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from modes import Branch, Unstaged
+from pytest_picked.modes import Branch, Unstaged
 
 
 def test_check_parser():
@@ -21,7 +21,7 @@ def test_check_parser():
         + b" M tests_new/intestine.py\n"
     )
 
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         subprocess_mock.return_value.stdout = raw_output
         mode = Unstaged(test_file_convention)
         files, folders = mode.affected_tests()
@@ -45,12 +45,15 @@ def test_should_parse_branch_changed_files():
     )
     test_file_convention = ["test_*.py", "*_test.py"]
 
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         subprocess_mock.return_value.stdout = raw_output
         mode = Branch(test_file_convention)
         files, folders = mode.affected_tests()
 
-    expected_files = ["tests/test_pytest_picked.py", "tests/test_other_module.py"]
+    expected_files = [
+        "tests/test_pytest_picked.py",
+        "tests/test_other_module.py",
+    ]
     expected_folders = []
 
     assert files == expected_files

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+from modes import Branch, Unstaged
+
+
+def test_check_parser():
+    test_file_convention = ["test_*.py", "*_test.py"]
+    raw_output = (
+        b"R  school/migrations/from-school.csv -> test_new_things.py\n"
+        + b"D  school/migrations/0032_auto_20180515_1308.py\n"
+        + b"?? Pipfile\n"
+        + b"!! school/tests/test_rescue_students.py\n"
+        + b"C  tests/\n"
+        + b" M .pre-commit-config.yaml\n"
+        + b" M picked.py\n"
+        + b"A  setup.py\n"
+        + b" U tests/test_pytest_picked.py\n"
+        + b"?? random/tests/\n"
+        + b" M intestine.py\n"
+        + b"?? api/\n"
+        + b" M tests_new/intestine.py\n"
+    )
+
+    with patch("modes.subprocess.run") as subprocess_mock:
+        subprocess_mock.return_value.stdout = raw_output
+        mode = Unstaged(test_file_convention)
+        files, folders = mode.affected_tests()
+
+    expected_files = [
+        "test_new_things.py",
+        "school/tests/test_rescue_students.py",
+        "tests/test_pytest_picked.py",
+    ]
+    expected_folders = ["tests/", "random/tests/", "api/"]
+
+    assert files == expected_files
+    assert folders == expected_folders
+
+
+def test_should_parse_branch_changed_files():
+    raw_output = (
+        b"pytest_picked.py\n"
+        + b"tests/test_pytest_picked.py\n"
+        + b"tests/test_other_module.py"
+    )
+    test_file_convention = ["test_*.py", "*_test.py"]
+
+    with patch("modes.subprocess.run") as subprocess_mock:
+        subprocess_mock.return_value.stdout = raw_output
+        mode = Branch(test_file_convention)
+        files, folders = mode.affected_tests()
+
+    expected_files = ["tests/test_pytest_picked.py", "tests/test_other_module.py"]
+    expected_folders = []
+
+    assert files == expected_files
+    assert folders == expected_folders

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-from pytest_picked import _affected_tests
-
 
 def test_shows_affected_tests(testdir):
     result = testdir.runpytest("--picked")
@@ -19,7 +17,7 @@ def test_help_message(testdir):
 
 
 def test_filter_items_according_with_git_status(testdir, tmpdir):
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
         output = b" M test_flows.py\n M test_serializers.py\n A tests/\n"
         subprocess_mock.return_value.stdout = output
 
@@ -46,7 +44,7 @@ def test_filter_items_according_with_git_status(testdir, tmpdir):
 
 
 def test_return_nothing_if_does_not_have_changed_test_files(testdir):
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
         subprocess_mock.return_value.stdout = b""
 
         result = testdir.runpytest("--picked")
@@ -56,7 +54,7 @@ def test_return_nothing_if_does_not_have_changed_test_files(testdir):
 
 def test_return_error_if_not_git_repository(testdir):
     o = b"fatal: Not a git repository (or any of the parent directories): .git"
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
 
         subprocess_mock.return_value.stdout = o
 
@@ -72,7 +70,7 @@ def test_dont_call_the_plugin_if_dont_find_it_as_option(testdir):
 
 
 def test_filter_file_when_is_either_modified_and_not_staged(testdir):
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
         output = b"MM test_picked.py\nM  tests/test_pytest_picked.py"
         subprocess_mock.return_value.stdout = output
 
@@ -98,7 +96,7 @@ def test_filter_file_when_is_either_modified_and_not_staged(testdir):
 
 
 def test_handle_with_white_spaces(testdir):
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
         output = (
             b" M school/tests/test_flows.py\n"
             + b"A  school/tests/test_serializers.py\n M sales/tasks.py"
@@ -127,39 +125,8 @@ def test_handle_with_white_spaces(testdir):
         )
 
 
-def test_check_parser():
-    test_file_convention = ["test_*.py", "*_test.py"]
-    raw_output = (
-        "R  school/migrations/from-school.csv -> test_new_things.py\n"
-        + "D  school/migrations/0032_auto_20180515_1308.py\n"
-        + "?? Pipfile\n"
-        + "!! school/tests/test_rescue_students.py\n"
-        + "C  tests/\n"
-        + " M .pre-commit-config.yaml\n"
-        + " M picked.py\n"
-        + "A  setup.py\n"
-        + " U tests/test_pytest_picked.py\n"
-        + "?? random/tests/\n"
-        + " M intestine.py\n"
-        + "?? api/\n"
-        + " M tests_new/intestine.py\n"
-    )
-
-    files, folders = _affected_tests(raw_output, test_file_convention)
-
-    expected_files = [
-        "test_new_things.py",
-        "school/tests/test_rescue_students.py",
-        "tests/test_pytest_picked.py",
-    ]
-    expected_folders = ["tests/", "random/tests/", "api/"]
-
-    assert files == expected_files
-    assert folders == expected_folders
-
-
 def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
         output = b" A tests/\n"
         subprocess_mock.return_value.stdout = output
 
@@ -172,25 +139,8 @@ def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
         )
 
 
-def test_should_parse_branch_changed_files():
-    raw_output = (
-        "pytest_picked.py\n"
-        + "tests/test_pytest_picked.py\n"
-        + "tests/test_other_module.py"
-    )
-    test_file_convention = ["test_*.py", "*_test.py"]
-
-    files, folders = _affected_tests(raw_output, test_file_convention, mode="branch")
-
-    expected_files = ["tests/test_pytest_picked.py", "tests/test_other_module.py"]
-    expected_folders = []
-
-    assert files == expected_files
-    assert folders == expected_folders
-
-
 def test_should_accept_branch_as_mode(testdir, tmpdir):
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+    with patch("modes.subprocess.run") as subprocess_mock:
         output = b"test_flows.py\ntest_serializers.py\n"
         subprocess_mock.return_value.stdout = output
 

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -172,10 +172,6 @@ def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
         )
 
 
-def test_should_accept_branch_as_mode():
-    pass
-
-
 def test_should_parse_branch_changed_files():
     raw_output = (
         "pytest_picked.py\n"
@@ -191,3 +187,30 @@ def test_should_parse_branch_changed_files():
 
     assert files == expected_files
     assert folders == expected_folders
+
+
+def test_should_accept_branch_as_mode(testdir, tmpdir):
+    with patch("pytest_picked.subprocess.run") as subprocess_mock:
+        output = b"test_flows.py\ntest_serializers.py\n"
+        subprocess_mock.return_value.stdout = output
+
+        result = testdir.runpytest("--picked", "--mode=branch")
+        testdir.makepyfile(
+            ".py",
+            test_flows="""
+            def test_sth():
+                assert True
+            """,
+            test_serializers="""
+            def test_sth():
+                assert True
+            """,
+        )
+        tmpdir.mkdir("tests")
+        result.stdout.fnmatch_lines(
+            [
+                "Changed test files... 2. "
+                + "['test_flows.py', 'test_serializers.py']",
+                "Changed test folders... 0. []",
+            ]
+        )

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -167,3 +167,12 @@ def test_should_accept_branch_as_mode(testdir, tmpdir):
                 "Changed test folders... 0. []",
             ]
         )
+
+
+def test_should_not_run_the_tests_if_mode_is_invalid(testdir, tmpdir):
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
+        output = b"test_flows.py\ntest_serializers.py\n"
+        subprocess_mock.return_value.stdout = output
+
+        result = testdir.runpytest("--picked", "--mode=random")
+        result.stdout.re_match_lines(["Invalid mode. Options: "])

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -17,7 +17,7 @@ def test_help_message(testdir):
 
 
 def test_filter_items_according_with_git_status(testdir, tmpdir):
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         output = b" M test_flows.py\n M test_serializers.py\n A tests/\n"
         subprocess_mock.return_value.stdout = output
 
@@ -44,7 +44,7 @@ def test_filter_items_according_with_git_status(testdir, tmpdir):
 
 
 def test_return_nothing_if_does_not_have_changed_test_files(testdir):
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         subprocess_mock.return_value.stdout = b""
 
         result = testdir.runpytest("--picked")
@@ -54,7 +54,7 @@ def test_return_nothing_if_does_not_have_changed_test_files(testdir):
 
 def test_return_error_if_not_git_repository(testdir):
     o = b"fatal: Not a git repository (or any of the parent directories): .git"
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
 
         subprocess_mock.return_value.stdout = o
 
@@ -70,7 +70,7 @@ def test_dont_call_the_plugin_if_dont_find_it_as_option(testdir):
 
 
 def test_filter_file_when_is_either_modified_and_not_staged(testdir):
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         output = b"MM test_picked.py\nM  tests/test_pytest_picked.py"
         subprocess_mock.return_value.stdout = output
 
@@ -96,7 +96,7 @@ def test_filter_file_when_is_either_modified_and_not_staged(testdir):
 
 
 def test_handle_with_white_spaces(testdir):
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         output = (
             b" M school/tests/test_flows.py\n"
             + b"A  school/tests/test_serializers.py\n M sales/tasks.py"
@@ -126,7 +126,7 @@ def test_handle_with_white_spaces(testdir):
 
 
 def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         output = b" A tests/\n"
         subprocess_mock.return_value.stdout = output
 
@@ -135,12 +135,15 @@ def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
         tmpdir.mkdir("othertests")
 
         result.stdout.fnmatch_lines(
-            ["Changed test files... 0. []", "Changed test folders... 1. ['tests/']"]
+            [
+                "Changed test files... 0. []",
+                "Changed test folders... 1. ['tests/']",
+            ]
         )
 
 
 def test_should_accept_branch_as_mode(testdir, tmpdir):
-    with patch("modes.subprocess.run") as subprocess_mock:
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
         output = b"test_flows.py\ntest_serializers.py\n"
         subprocess_mock.return_value.stdout = output
 

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -128,36 +128,34 @@ def test_handle_with_white_spaces(testdir):
 
 
 def test_check_parser():
-    with patch("pytest_picked.subprocess.run") as subprocess_mock:
-        output = (
-            b"R  school/migrations/from-school.csv -> test_new_things.py\n"
-            + b"D  school/migrations/0032_auto_20180515_1308.py\n"
-            + b"?? Pipfile\n"
-            + b"!! school/tests/test_rescue_students.py\n"
-            + b"C  tests/\n"
-            + b" M .pre-commit-config.yaml\n"
-            + b" M picked.py\n"
-            + b"A  setup.py\n"
-            + b" U tests/test_pytest_picked.py\n"
-            + b"?? random/tests/\n"
-            + b" M intestine.py\n"
-            + b"?? api/\n"
-            + b" M tests_new/intestine.py\n"
-        )
+    test_file_convention = ["test_*.py", "*_test.py"]
+    raw_output = (
+        "R  school/migrations/from-school.csv -> test_new_things.py\n"
+        + "D  school/migrations/0032_auto_20180515_1308.py\n"
+        + "?? Pipfile\n"
+        + "!! school/tests/test_rescue_students.py\n"
+        + "C  tests/\n"
+        + " M .pre-commit-config.yaml\n"
+        + " M picked.py\n"
+        + "A  setup.py\n"
+        + " U tests/test_pytest_picked.py\n"
+        + "?? random/tests/\n"
+        + " M intestine.py\n"
+        + "?? api/\n"
+        + " M tests_new/intestine.py\n"
+    )
 
-        subprocess_mock.return_value.stdout = output
-        test_files = ["test_*.py", "*_test.py"]
-        files, folders = _affected_tests(test_files)
+    files, folders = _affected_tests(raw_output, test_file_convention)
 
-        expected_files = [
-            "test_new_things.py",
-            "school/tests/test_rescue_students.py",
-            "tests/test_pytest_picked.py",
-        ]
-        expected_folders = ["tests/", "random/tests/", "api/"]
+    expected_files = [
+        "test_new_things.py",
+        "school/tests/test_rescue_students.py",
+        "tests/test_pytest_picked.py",
+    ]
+    expected_folders = ["tests/", "random/tests/", "api/"]
 
-        assert files == expected_files
-        assert folders == expected_folders
+    assert files == expected_files
+    assert folders == expected_folders
 
 
 def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
@@ -170,8 +168,26 @@ def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
         tmpdir.mkdir("othertests")
 
         result.stdout.fnmatch_lines(
-            [
-                "Changed test files... 0. []",
-                "Changed test folders... 1. ['tests/']",
-            ]
+            ["Changed test files... 0. []", "Changed test folders... 1. ['tests/']"]
         )
+
+
+def test_should_accept_branch_as_mode():
+    pass
+
+
+def test_should_parse_branch_changed_files():
+    raw_output = (
+        "pytest_picked.py\n"
+        + "tests/test_pytest_picked.py\n"
+        + "tests/test_other_module.py"
+    )
+    test_file_convention = ["test_*.py", "*_test.py"]
+
+    files, folders = _affected_tests(raw_output, test_file_convention, mode="branch")
+
+    expected_files = ["tests/test_pytest_picked.py", "tests/test_other_module.py"]
+    expected_folders = []
+
+    assert files == expected_files
+    assert folders == expected_folders

--- a/tox.ini
+++ b/tox.ini
@@ -8,4 +8,4 @@ commands = pytest {posargs:tests}
 [testenv:black]
 skip_install = true
 deps = black
-commands = black --line-length 80 --exclude build/|docs/|dist/|_build/|\.git/|\.hg/|\.pytest_cache/|\.tox/|\.venv/ --check .
+commands = black --line-length 80 --check .


### PR DESCRIPTION
Now it is possible to run the tests modified on the current branch using the syntax `pytest --picked --mode=branch`. Solves https://github.com/anapaulagomes/pytest-picked/issues/2.

More tests need to be added and the current ones cleaned up.

To think about it:
- I'm assuming that `master` is always the source of truth
- I didn't test in a branch with merges/rebases etc yet

Feedback is welcome!