### PR TITLE
Add badges for conda-forge and Python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,14 @@ pytest-picked
 .. image:: https://img.shields.io/pypi/v/pytest-picked.svg
     :target: https://pypi.org/project/pytest-picked/
     :alt: See Package Status on PyPI
+    
+.. image:: https://img.shields.io/conda/vn/conda-forge/pytest-picked.svg
+    :target: https://anaconda.org/conda-forge/pytest-picked 
+    :alt: Conda forge package
+    
+.. image:: https://img.shields.io/pypi/pyversions/pytest-picked.svg
+    :target: https://pypi.org/project/pytest-picked    
+    :alt: Supported Python versions
 
 Run the tests related to the modified files (according to Git)
 


### PR DESCRIPTION
Congratulations on the new plugin!

I've added a [conda-forge package](https://github.com/conda-forge/pytest-picked-feedstock) for the plugin so I thought it would be nice to have a badge for that on the README. While at it I added a "supported python versions" badge which we use at pytest, because it lets readers know at a glance which Python versions this plugin supports.

Keep up the excellent work! 👍