### PR TITLE
Implement --picked=first, which will run the changed tests first, then everything else afterwards

### DIFF
--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 
 
 class Mode(ABC):
-
     def __init__(self, test_file_convention):
         self.test_file_convention = test_file_convention
 
@@ -28,8 +27,7 @@ class Mode(ABC):
         return files, folders
 
     def git_output(self):
-        output = subprocess.run(  # nosec
-            self.command(), stdout=subprocess.PIPE)
+        output = subprocess.run(self.command(), stdout=subprocess.PIPE)  # nosec
         return output.stdout.decode("utf-8")
 
     def print_command(self):
@@ -51,7 +49,6 @@ class Mode(ABC):
 
 
 class Branch(Mode):
-
     def command(self):
         return ["git", "diff", "--name-only", "master"]
 
@@ -61,7 +58,6 @@ class Branch(Mode):
 
 
 class Unstaged(Mode):
-
     def command(self):
         return ["git", "status", "--short"]
 

--- a/pytest_picked/plugin.py
+++ b/pytest_picked/plugin.py
@@ -7,9 +7,15 @@ def pytest_addoption(parser):
     group = parser.getgroup("picked")
     group.addoption(
         "--picked",
-        action="store_true",
+        action="store",
         dest="picked",
-        help="Run the tests related to the changed files",
+        choices=("only", "first"),
+        nargs="?",
+        const="only",
+        help=(
+            "Run the tests related to the changed files either on their own, "
+            "or first"
+        ),
     )
     group.addoption(
         "--mode",

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -6,7 +6,6 @@ from pytest_picked.modes import Branch, Unstaged
 
 
 class TestUnstaged:
-
     def test_should_return_git_status_command(self):
         mode = Unstaged([])
         command = mode.command()
@@ -74,7 +73,6 @@ class TestUnstaged:
 
 
 class TestBranch:
-
     def test_should_return_command_that_list_all_changed_files(self):
         mode = Branch([])
         command = mode.command()

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+import pytest
 
 
 def test_shows_affected_tests(testdir):
@@ -11,9 +12,23 @@ def test_shows_affected_tests(testdir):
 def test_help_message(testdir):
     result = testdir.runpytest("--help")
 
-    result.stdout.fnmatch_lines(
-        ["picked:", "*--picked*Run the tests related to the changed files"]
-    )
+    result.stdout.re_match_lines([
+        "^picked:$",
+        r"^\s+--picked=\[{only,first}\]$",
+        r"^\s+Run the tests related to the changed files either on",
+        r"^\s+their own, or first",
+    ])
+
+
+@pytest.mark.parametrize("picked_type", [None, "only"])
+def test_picked_type_options(testdir, picked_type):
+    with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
+        subprocess_mock.return_value.stdout = b""
+
+        result = testdir.runpytest(
+            "--picked={}".format(picked_type) if picked_type else "--picked")
+
+        result.stdout.fnmatch_lines(["Changed test files... 0. []"])
 
 
 def test_filter_items_according_with_git_status(testdir, tmpdir):

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -12,12 +12,14 @@ def test_shows_affected_tests(testdir):
 def test_help_message(testdir):
     result = testdir.runpytest("--help")
 
-    result.stdout.re_match_lines([
-        "^picked:$",
-        r"^\s+--picked=\[{only,first}\]$",
-        r"^\s+Run the tests related to the changed files either on",
-        r"^\s+their own, or first",
-    ])
+    result.stdout.re_match_lines(
+        [
+            "^picked:$",
+            r"^\s+--picked=\[{only,first}\]$",
+            r"^\s+Run the tests related to the changed files either on",
+            r"^\s+their own, or first",
+        ]
+    )
 
 
 @pytest.mark.parametrize("picked_type", [None, "only"])
@@ -26,7 +28,8 @@ def test_picked_type_options(testdir, picked_type):
         subprocess_mock.return_value.stdout = b""
 
         result = testdir.runpytest(
-            "--picked={}".format(picked_type) if picked_type else "--picked")
+            "--picked={}".format(picked_type) if picked_type else "--picked"
+        )
 
         result.stdout.fnmatch_lines(["Changed test files... 0. []"])
 
@@ -217,12 +220,14 @@ def test_picked_first_orders_tests_correctly(testdir, tmpdir):
             """,
         )
         result = testdir.runpytest("--picked=first", "-v")
-        result.stdout.re_match_lines([
-            "test_flows.py.+",
-            "test_serializers.py.+",
-            "test_access.py.+",
-            "test_views.py.+",
-        ])
+        result.stdout.re_match_lines(
+            [
+                "test_flows.py.+",
+                "test_serializers.py.+",
+                "test_access.py.+",
+                "test_views.py.+",
+            ]
+        )
 
 
 def test_picked_first_but_nothing_changed(testdir, tmpdir):


### PR DESCRIPTION
This adds the ability to schedule changed files to be run first, ahead of all the other tests. It looks like this implements the change asked for in #18 as well.

I was toying with putting all the logic into the `pytest_collection_modifyitems` hook, rather than splitting it based on whether we're in `--picked=first` or `--picked=only` mode, but decided against it as if the user has asked for *just* the changed files, then there's no point pytest running collection over everything, and then filtering it later. What do you think about this?