### PR TITLE
 Fix branch mode where pytest root is not git root 

### DIFF
--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -52,7 +52,7 @@ class Mode(ABC):
 class Branch(Mode):
 
     def command(self):
-        return ["git", "diff", "--name-only", "master"]
+        return ["git", "diff", "--name-only", "--relative", "master"]
 
     def parser(self, candidate):
         """The candidate itself."""

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -117,7 +117,6 @@ class TestBranch:
         assert folders == expected_folders
 
     def test_should_list_changed_files(self, testdir):
-        # initialize a new git repo in testdir/gitroot
         gitroot = testdir.mkdir("gitroot")
         gitroot.chdir()
         try:
@@ -125,23 +124,18 @@ class TestBranch:
         except FileNotFoundError:
             pytest.skip("required executable 'git' not found")
 
-        # provide git-commit a valid committer and author
         if "EMAIL" not in os.environ:
             os.environ["EMAIL"] = "_"
 
-        # create master branch with empty initial commit
         assert testdir.run("git", "commit", "--allow-empty", "-m_").ret == 0
 
-        # create a file to detect and add to git
         gitroot.join("test_gitroot").new(ext="py").write(b"", "wb")
         assert testdir.run("git", "add", ".").ret == 0
 
-        # assert only above file is detected
         output = set(Branch([]).git_output().splitlines())
         assert output == {"test_gitroot.py"}
 
     def test_should_only_list_changed_files_under_pytest_root(self, testdir):
-        # initialize a new git repo in testdir/gitroot
         gitroot = testdir.mkdir("gitroot")
         gitroot.chdir()
         try:
@@ -149,27 +143,19 @@ class TestBranch:
         except FileNotFoundError:
             pytest.skip("required executable 'git' not found")
 
-        # provide git-commit a valid committer and author
         if "EMAIL" not in os.environ:
             os.environ["EMAIL"] = "_"
 
-        # create master branch with empty initial commit
         assert testdir.run("git", "commit", "--allow-empty", "-m_").ret == 0
 
-        # create a file outside pytestroot
         gitroot.join("test_gitroot").new(ext="py").write(b"", "wb")
-        # create testdir/gitroot/pytestroot
         pytestroot = gitroot.mkdir("pytestroot")
-        # create a file inside pytestroot
         pytestroot.join("test_pytestroot").new(ext="py").write(b"", "wb")
-        # add above changed files to git
         assert testdir.run("git", "add", ".").ret == 0
 
-        # assert that all files are detected from gitroot
         output = set(Branch([]).git_output().splitlines())
         assert output == {"test_gitroot.py", "pytestroot/test_pytestroot.py"}
 
-        # assert that only one file is detected from pytestroot
         pytestroot.chdir()
         output = set(Branch([]).git_output().splitlines())
         assert output == {"test_pytestroot.py"}


### PR DESCRIPTION
adding `--relative` ensures that the branch command is relative to the pytest root instead of the git root