### PR TITLE
Use `git diff name-status` for branch mode

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,2 +1,0 @@
-branch: dev
-schedule: every week

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,2 @@
+branch: dev
+schedule: every week

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -28,7 +28,8 @@ class Mode(ABC):
 
     def git_output(self):
         output = subprocess.run(self.command(), stdout=subprocess.PIPE)  # nosec
-        return output.stdout.decode("utf-8")
+        return output.stdout.decode("utf-8").expandtabs()
+
 
     def print_command(self):
         return " ".join(self.command())

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -74,8 +74,7 @@ class Branch(Mode):
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---name-status
         """
         start_path_index = 8
-        rename_regex = r"^R[0-9]\d\d {4}"
-        rename_separator = "     "
+        rename_regex = r"^R\d+.*\s{5}(.*)"
         delete_indicator = "D       "
         deleted_and_renamed_indicator = "AD      "
 
@@ -83,9 +82,10 @@ class Branch(Mode):
             return
         if candidate.startswith(deleted_and_renamed_indicator):
             return
+        rename_matching = re.match(rename_regex, candidate)
         if re.match(rename_regex, candidate):
-            indicator_index = candidate.find(rename_separator)
-            start_path_index = indicator_index + len(rename_separator)
+            if rename_matching:
+                return rename_matching.group(1)
         return candidate[start_path_index:]
 
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -54,38 +54,35 @@ class Branch(Mode):
 
     def parser(self, candidate):
         """
-        Discard the first 8 characters.
+        Discard the first 3 characters.
 
-        Parse affected tests from Branch command.
+        Parse affected tests from Unstaged command.
         The command output would look like this:
-        D       .pyup.yml
-        M       pytest_picked/modes.py
-        M       requirements.txt
-        M       requirements_test.txt
-        M       tests/test_modes.py
-        R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py
+        A  setup.py
+        U tests/test_pytest_picked.py
+        ?? .pylintrc
+        D  tests/migrations/auto.py
         The first two digits are M, A, D, R, C, U, ? or !
-        R and C include a percentage of how different the diffed file is, represented as 3 integers.
-        The rest of the characters up until the 9th character are spaces.
-        If the file was deleted it will have a D at the beginning of the line.
-        If the file was renamed, it will have 5 spaces between the filenames and look like this:
-        R100  school/migrations/from-school.csv     school/migrations/new-things-from-school.csv
+        The third is a white-space and the left is the path of
+        the file.
+        If the file was deleted it will have a D at the beginning
+        of the line. If the file was renamed, it will look like this:
+        R  school/migrations/from-school.csv -> new-things-from-school.csv
         Reference:
-        https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---name-status
+        https://git-scm.com/docs/git-status#git-status---short
         """
-        start_path_index = 8
-        rename_regex = "^R[0-9]\d\d {4}"
-        rename_seperator = "     "
-        delete_indicator = "D       "
-        deleted_and_renamed_indicator = "AD      "
+        start_path_index = 3
+        rename_indicator = "-> "
+        delete_indicator = " D "
+        deleted_and_renamed_indicator = "AD "
 
         if candidate.startswith(delete_indicator):
             return None
         if candidate.startswith(deleted_and_renamed_indicator):
             return None
-        if re.match(rename_regex, candidate):
-            indicator_index = candidate.find(rename_seperator)
-            start_path_index = indicator_index + len(rename_seperator)
+        if rename_indicator in candidate:
+            indicator_index = candidate.find(rename_indicator)
+            start_path_index = indicator_index + len(rename_indicator)
         return candidate[start_path_index:]
 
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -30,7 +30,6 @@ class Mode(ABC):
         output = subprocess.run(self.command(), stdout=subprocess.PIPE)  # nosec
         return output.stdout.decode("utf-8").expandtabs()
 
-
     def print_command(self):
         return " ".join(self.command())
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -83,9 +83,9 @@ class Branch(Mode):
             return
         if candidate.startswith(deleted_and_renamed_indicator):
             return
-        rename_matching = re.match(rename_regex, candidate)
-        if rename_matching:
-            return rename_matching.group(1)
+        if re.match(rename_regex, candidate):
+            indicator_index = candidate.find(rename_separator)
+            start_path_index = indicator_index + len(rename_separator)
         return candidate[start_path_index:]
 
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -54,35 +54,38 @@ class Branch(Mode):
 
     def parser(self, candidate):
         """
-        Discard the first 3 characters.
+        Discard the first 8 characters.
 
-        Parse affected tests from Unstaged command.
+        Parse affected tests from Branch command.
         The command output would look like this:
-        A  setup.py
-        U tests/test_pytest_picked.py
-        ?? .pylintrc
-        D  tests/migrations/auto.py
+        D       .pyup.yml
+        M       pytest_picked/modes.py
+        M       requirements.txt
+        M       requirements_test.txt
+        M       tests/test_modes.py
+        R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py
         The first two digits are M, A, D, R, C, U, ? or !
-        The third is a white-space and the left is the path of
-        the file.
-        If the file was deleted it will have a D at the beginning
-        of the line. If the file was renamed, it will look like this:
-        R  school/migrations/from-school.csv -> new-things-from-school.csv
+        R and C include a percentage of how different the diffed file is, represented as 3 integers.
+        The rest of the characters up until the 9th character are spaces.
+        If the file was deleted it will have a D at the beginning of the line.
+        If the file was renamed, it will have 5 spaces between the filenames and look like this:
+        R100  school/migrations/from-school.csv     school/migrations/new-things-from-school.csv
         Reference:
-        https://git-scm.com/docs/git-status#git-status---short
+        https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---name-status
         """
-        start_path_index = 3
-        rename_indicator = "-> "
-        delete_indicator = " D "
-        deleted_and_renamed_indicator = "AD "
+        start_path_index = 8
+        rename_regex = "^R[0-9]\d\d {4}"
+        rename_seperator = "     "
+        delete_indicator = "D       "
+        deleted_and_renamed_indicator = "AD      "
 
         if candidate.startswith(delete_indicator):
             return None
         if candidate.startswith(deleted_and_renamed_indicator):
             return None
-        if rename_indicator in candidate:
-            indicator_index = candidate.find(rename_indicator)
-            start_path_index = indicator_index + len(rename_indicator)
+        if re.match(rename_regex, candidate):
+            indicator_index = candidate.find(rename_seperator)
+            start_path_index = indicator_index + len(rename_seperator)
         return candidate[start_path_index:]
 
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -82,7 +82,7 @@ class Branch(Mode):
         if candidate.startswith(delete_indicator):
             return
         if candidate.startswith(deleted_and_renamed_indicator):
-            return None
+            return
         if re.match(rename_regex, candidate):
             indicator_index = candidate.find(rename_seperator)
             start_path_index = indicator_index + len(rename_seperator)

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -80,7 +80,7 @@ class Branch(Mode):
         deleted_and_renamed_indicator = "AD      "
 
         if candidate.startswith(delete_indicator):
-            return None
+            return
         if candidate.startswith(deleted_and_renamed_indicator):
             return None
         if re.match(rename_regex, candidate):

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -74,7 +74,7 @@ class Branch(Mode):
         https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---name-status
         """
         start_path_index = 8
-        rename_regex = "^R[0-9]\d\d {4}"
+        rename_regex = r"^R[0-9]\d\d {4}"
         rename_seperator = "     "
         delete_indicator = "D       "
         deleted_and_renamed_indicator = "AD      "

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -75,7 +75,7 @@ class Branch(Mode):
         """
         start_path_index = 8
         rename_regex = r"^R[0-9]\d\d {4}"
-        rename_seperator = "     "
+        rename_separator = "     "
         delete_indicator = "D       "
         deleted_and_renamed_indicator = "AD      "
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -83,9 +83,9 @@ class Branch(Mode):
             return
         if candidate.startswith(deleted_and_renamed_indicator):
             return
-        if re.match(rename_regex, candidate):
-            indicator_index = candidate.find(rename_seperator)
-            start_path_index = indicator_index + len(rename_seperator)
+        rename_matching = re.match(rename_regex, candidate)
+        if rename_matching:
+            return rename_matching.group(1)
         return candidate[start_path_index:]
 
 

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -83,9 +83,8 @@ class Branch(Mode):
         if candidate.startswith(deleted_and_renamed_indicator):
             return
         rename_matching = re.match(rename_regex, candidate)
-        if re.match(rename_regex, candidate):
-            if rename_matching:
-                return rename_matching.group(1)
+        if rename_matching:
+            return rename_matching.group(1)
         return candidate[start_path_index:]
 
 

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -83,15 +83,24 @@ class TestBranch:
         command = mode.command()
 
         assert isinstance(command, list)
-        assert mode.command() == ["git", "diff", "--name-status", "--relative", "master"]
+        assert mode.command() == [
+            "git",
+            "diff",
+            "--name-status",
+            "--relative",
+            "master",
+        ]
 
     @pytest.mark.parametrize(
         "line,expected_line",
         [
             ("D       tests/migrations/auto.py", None),
-            ("R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py", "tests/test_pytest_picked.py"),
+            (
+                "R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py",
+                "tests/test_pytest_picked.py",
+            ),
             ("M       test.py", "test.py"),
-            ("AD      test.py", None)
+            ("AD      test.py", None),
         ],
     )
     def test_parser_should_ignore_no_paths_characters(self, line, expected_line):

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -85,18 +85,26 @@ class TestBranch:
         assert isinstance(command, list)
         assert mode.command() == ["git", "diff", "--name-only", "--relative", "master"]
 
-    def test_parser_should_return_the_candidate_itself(self):
+    @pytest.mark.parametrize(
+        "line,expected_line",
+        [
+            ("D       tests/migrations/auto.py", None),
+            ("R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py", "tests/test_pytest_picked.py"),
+            ("M       test.py", "test.py"),
+            ("AD      test.py", None)
+        ],
+    )
+    def test_parser_should_ignore_no_paths_characters(self, line, expected_line):
         mode = Branch([])
-        line = "tests/test_pytest_picked.py\n"
         parsed_line = mode.parser(line)
 
-        assert parsed_line == line
+        assert parsed_line == expected_line
 
     def test_should_list_branch_changed_files_as_affected_tests(self):
         raw_output = (
-            b"pytest_picked.py\n"
-            + b"tests/test_pytest_picked.py\n"
-            + b"tests/test_other_module.py"
+            b"D       pytest_picked.py\n"
+            + b"R066    tests/test_pytest_picked.py     tests/test_pytest_picked.py\n"
+            + b"M       tests/test_other_module.py"
         )
         test_file_convention = ["test_*.py", "*_test.py"]
 
@@ -124,7 +132,7 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"test_gitroot.py"}
+        assert output == {"A\ttest_gitroot.py"}
 
     def test_should_only_list_pytestroot_changed_files(self, email, testdir):
         gitroot = testdir.mkdir("gitroot")
@@ -141,8 +149,8 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"test_gitroot.py", "pytestroot/test_pytestroot.py"}
+        assert output == {"A\ttest_gitroot.py", "A\tpytestroot/test_pytestroot.py"}
 
         pytestroot.chdir()
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"test_pytestroot.py"}
+        assert output == {"A\ttest_pytestroot.py"}

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -85,18 +85,26 @@ class TestBranch:
         assert isinstance(command, list)
         assert mode.command() == ["git", "diff", "--name-status", "--relative", "master"]
 
-    def test_parser_should_return_the_candidate_itself(self):
+    @pytest.mark.parametrize(
+        "line,expected_line",
+        [
+            ("D       tests/migrations/auto.py", None),
+            ("R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py", "tests/test_pytest_picked.py"),
+            ("M       test.py", "test.py"),
+            ("AD      test.py", None)
+        ],
+    )
+    def test_parser_should_ignore_no_paths_characters(self, line, expected_line):
         mode = Branch([])
-        line = "tests/test_pytest_picked.py\n"
         parsed_line = mode.parser(line)
 
-        assert parsed_line == line
+        assert parsed_line == expected_line
 
     def test_should_list_branch_changed_files_as_affected_tests(self):
         raw_output = (
-            b"pytest_picked.py\n"
-            + b"tests/test_pytest_picked.py\n"
-            + b"tests/test_other_module.py"
+            b"D       pytest_picked.py\n"
+            + b"R066    tests/test_pytest_picked.py     tests/test_pytest_picked.py\n"
+            + b"M       tests/test_other_module.py"
         )
         test_file_convention = ["test_*.py", "*_test.py"]
 
@@ -124,7 +132,7 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"test_gitroot.py"}
+        assert output == {"A\ttest_gitroot.py"}
 
     def test_should_only_list_pytestroot_changed_files(self, email, testdir):
         gitroot = testdir.mkdir("gitroot")
@@ -141,8 +149,8 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"test_gitroot.py", "pytestroot/test_pytestroot.py"}
+        assert output == {"A\ttest_gitroot.py", "A\tpytestroot/test_pytestroot.py"}
 
         pytestroot.chdir()
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"test_pytestroot.py"}
+        assert output == {"A\ttest_pytestroot.py"}

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -83,7 +83,7 @@ class TestBranch:
         command = mode.command()
 
         assert isinstance(command, list)
-        assert mode.command() == ["git", "diff", "--name-status", "--relative", "master"]
+        assert mode.command() == ["git", "diff", "--name-only", "--relative", "master"]
 
     @pytest.mark.parametrize(
         "line,expected_line",

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -85,26 +85,18 @@ class TestBranch:
         assert isinstance(command, list)
         assert mode.command() == ["git", "diff", "--name-only", "--relative", "master"]
 
-    @pytest.mark.parametrize(
-        "line,expected_line",
-        [
-            ("D       tests/migrations/auto.py", None),
-            ("R098    tests/test_pytest_picked.py     tests/test_pytest_picked.py", "tests/test_pytest_picked.py"),
-            ("M       test.py", "test.py"),
-            ("AD      test.py", None)
-        ],
-    )
-    def test_parser_should_ignore_no_paths_characters(self, line, expected_line):
+    def test_parser_should_return_the_candidate_itself(self):
         mode = Branch([])
+        line = "tests/test_pytest_picked.py\n"
         parsed_line = mode.parser(line)
 
-        assert parsed_line == expected_line
+        assert parsed_line == line
 
     def test_should_list_branch_changed_files_as_affected_tests(self):
         raw_output = (
-            b"D       pytest_picked.py\n"
-            + b"R066    tests/test_pytest_picked.py     tests/test_pytest_picked.py\n"
-            + b"M       tests/test_other_module.py"
+            b"pytest_picked.py\n"
+            + b"tests/test_pytest_picked.py\n"
+            + b"tests/test_other_module.py"
         )
         test_file_convention = ["test_*.py", "*_test.py"]
 
@@ -132,7 +124,7 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A\ttest_gitroot.py"}
+        assert output == {"test_gitroot.py"}
 
     def test_should_only_list_pytestroot_changed_files(self, email, testdir):
         gitroot = testdir.mkdir("gitroot")
@@ -149,8 +141,8 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A\ttest_gitroot.py", "A\tpytestroot/test_pytestroot.py"}
+        assert output == {"test_gitroot.py", "pytestroot/test_pytestroot.py"}
 
         pytestroot.chdir()
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A\ttest_pytestroot.py"}
+        assert output == {"test_pytestroot.py"}

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -122,7 +122,10 @@ class TestBranch:
             mode = Branch(test_file_convention)
             files, folders = mode.affected_tests()
 
-        expected_files = ["tests/test_new_pytest_picked.py", "tests/test_other_module.py"]
+        expected_files = [
+            "tests/test_new_pytest_picked.py",
+            "tests/test_other_module.py",
+        ]
         expected_folders = []
 
         assert files == expected_files

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -144,7 +144,7 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A\ttest_gitroot.py"}
+        assert output == {"A       test_gitroot.py"}
 
     def test_should_only_list_pytestroot_changed_files(self, email, testdir):
         gitroot = testdir.mkdir("gitroot")
@@ -161,8 +161,8 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A\ttest_gitroot.py", "A\tpytestroot/test_pytestroot.py"}
+        assert output == {"A       test_gitroot.py", "A       pytestroot/test_pytestroot.py"}
 
         pytestroot.chdir()
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A\ttest_pytestroot.py"}
+        assert output == {"A       test_pytestroot.py"}

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -83,7 +83,7 @@ class TestBranch:
         command = mode.command()
 
         assert isinstance(command, list)
-        assert mode.command() == ["git", "diff", "--name-only", "--relative", "master"]
+        assert mode.command() == ["git", "diff", "--name-status", "--relative", "master"]
 
     def test_parser_should_return_the_candidate_itself(self):
         mode = Branch([])

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -122,7 +122,7 @@ class TestBranch:
             mode = Branch(test_file_convention)
             files, folders = mode.affected_tests()
 
-        expected_files = ["tests/test_pytest_picked.py", "tests/test_other_module.py"]
+        expected_files = ["tests/test_new_pytest_picked.py", "tests/test_other_module.py"]
         expected_folders = []
 
         assert files == expected_files

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -83,7 +83,7 @@ class TestBranch:
         command = mode.command()
 
         assert isinstance(command, list)
-        assert mode.command() == ["git", "diff", "--name-only", "--relative", "master"]
+        assert mode.command() == ["git", "diff", "--name-status", "--relative", "master"]
 
     @pytest.mark.parametrize(
         "line,expected_line",

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -161,7 +161,10 @@ class TestBranch:
         assert testdir.run("git", "add", ".").ret == 0
 
         output = set(Branch([]).git_output().splitlines())
-        assert output == {"A       test_gitroot.py", "A       pytestroot/test_pytestroot.py"}
+        assert output == {
+            "A       test_gitroot.py",
+            "A       pytestroot/test_pytestroot.py",
+        }
 
         pytestroot.chdir()
         output = set(Branch([]).git_output().splitlines())

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -112,7 +112,7 @@ class TestBranch:
     def test_should_list_branch_changed_files_as_affected_tests(self):
         raw_output = (
             b"D       pytest_picked.py\n"
-            + b"R066    tests/test_pytest_picked.py     tests/test_pytest_picked.py\n"
+            + b"R066    tests/test_pytest_picked.py     tests/test_new_pytest_picked.py\n"
             + b"M       tests/test_other_module.py"
         )
         test_file_convention = ["test_*.py", "*_test.py"]

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -160,7 +160,7 @@ def test_should_match_with_the_begin_of_path(testdir, tmpdir, tmpdir_factory):
 
 def test_should_accept_branch_as_mode(testdir, tmpdir):
     with patch("pytest_picked.modes.subprocess.run") as subprocess_mock:
-        output = b"test_flows.py\ntest_serializers.py\n"
+        output = b"M       test_flows.py\nA       test_serializers.py\n"
         subprocess_mock.return_value.stdout = output
 
         result = testdir.runpytest("--picked", "--mode=branch")


### PR DESCRIPTION
Using `git diff --name-only` resulted in deleted files being included in the test run, which would fail our builds since the files no longer exist. Using `git diff --name-status` allows us to parse the branch-diffed files and skip the deleted ones.