### PR TITLE
Fix delete indicator for unstaged mode

### DIFF
--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -113,13 +113,13 @@ class Unstaged(Mode):
         """
         start_path_index = 3
         rename_indicator = "-> "
-        delete_indicator = " D "
+        delete_indicator = "D  "
         deleted_and_renamed_indicator = "AD "
 
         if candidate.startswith(delete_indicator):
-            return None
+            return
         if candidate.startswith(deleted_and_renamed_indicator):
-            return None
+            return
         if rename_indicator in candidate:
             indicator_index = candidate.find(rename_indicator)
             start_path_index = indicator_index + len(rename_indicator)

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -26,7 +26,7 @@ class TestUnstaged:
     @pytest.mark.parametrize(
         "line,expected_line",
         [
-            (" D tests/migrations/auto.py", None),
+            ("D  tests/migrations/auto.py", None),
             ("R  tests/from-school.csv -> test_new_things.py", "test_new_things.py"),
             (
                 "R  tests/from-school.csv -> tests/test_new_things.py",


### PR DESCRIPTION
The comment had the right indicator already but the method and its test had space before the `D`.

https://github.com/anapaulagomes/pytest-picked/blob/112562118035f80c046b164888c6fad63e1a72af/pytest_picked/modes.py#L73

To check if this command is the right one, delete a file that was already committed and run `git status --short`. Reference: https://git-scm.com/docs/git-status#git-status---short