### PR TITLE
Skip "Publish to Test PyPi" workflow when there is no change on setup.py

### DIFF
--- a/.github/workflows/publish_to_test_pypi.yml
+++ b/.github/workflows/publish_to_test_pypi.yml
@@ -3,6 +3,8 @@ name: Publish to Test PyPi
 on:
   push:
     branches: [dev]
+    paths: 
+      - 'setup.py'
 
 jobs:
   publish_to_test_pypi:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## [Unreleased] - 2020-10-03
-### Modified publish_to_test_pypi.yml
-- Skip "Publish to Test PyPi" workflow when there is no change on setup.py
-
 ## [Unreleased]
 ### Modified
 - Add fixture for git user configuration
+- Skip "Publish to Test PyPi" workflow when there is no change on setup.py
 
 ## [0.4.4] - 2020-03-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased] - 2020-10-03
+### Modified publish_to_test_pypi.yml
+- Skip "Publish to Test PyPi" workflow when there is no change on setup.py
+
 ## [Unreleased]
 ### Modified
 - Add fixture for git user configuration


### PR DESCRIPTION
fixes #105 

- set actions to run on push to dev and file path 'setup.py'
- the above should ensure the job only runs with changes to setup.py hence avoid unnecessary publishing to test pypi