### PR TITLE
fix: don't warn when using branch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Modified
+- No longer warns when using branch mode
 
 ## [0.5.1] - 2024-11-05
 ### Added

--- a/pytest_picked/modes.py
+++ b/pytest_picked/modes.py
@@ -52,7 +52,6 @@ class Mode(ABC):
 class Branch(Mode):
     def __init__(self, test_file_convention, parent_branch="main", **kwargs):
         super().__init__(test_file_convention, **kwargs)
-        warnings.warn("Now `main` is the default parent branch")
         self.parent_branch = parent_branch
 
     def command(self):

--- a/tests/test_modes.py
+++ b/tests/test_modes.py
@@ -105,11 +105,6 @@ class TestBranch:
             "main",
         ]
 
-    def test_should_warn_about_main_branch(self, recwarn):
-        Branch([])
-        assert len(recwarn) == 1
-        assert str(recwarn[0].message) == "Now `main` is the default parent branch"
-
     def test_should_return_command_that_list_all_changed_files_for_different_branch(
         self,
     ):

--- a/tests/test_pytest_picked.py
+++ b/tests/test_pytest_picked.py
@@ -162,7 +162,7 @@ def test_should_accept_branch_as_mode(testdir, tmpdir, recwarn):
         output = b"M       test_flows.py\nA       test_serializers.py\n"
         subprocess_mock.return_value.stdout = output
 
-        result = testdir.runpytest("--picked", "--mode=branch")
+
         testdir.makepyfile(
             ".py",
             test_flows="""
@@ -174,6 +174,7 @@ def test_should_accept_branch_as_mode(testdir, tmpdir, recwarn):
                 assert True
             """,
         )
+        result = testdir.runpytest("--picked", "--mode=branch")
         tmpdir.mkdir("tests")
         result.stdout.fnmatch_lines(
             [
@@ -182,8 +183,7 @@ def test_should_accept_branch_as_mode(testdir, tmpdir, recwarn):
                 "Changed test folders... 0. []",
             ]
         )
-        assert len(recwarn) == 1
-        assert str(recwarn[0].message) == "Now `main` is the default parent branch"
+        assert result.ret == 0
 
 
 def test_should_accept_unstaged_as_mode(testdir, tmpdir, recwarn):


### PR DESCRIPTION
- no more warnings for expected usage of the cli
- warning was not logging correct information when branch was not `main`
- fixed test that was falsely passing by ordering the action after the arrangement.